### PR TITLE
2022.09.07 stop publish when sub image stopped

### DIFF
--- a/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
+++ b/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
@@ -212,6 +212,9 @@ class YoloObjectDetector {
   int actionId_;
   boost::shared_mutex mutexActionStatus_;
 
+  // subscribe image time tolerance
+  double sub_img_time_tolerance;
+
   // double getWallTime();
 
   int sizeNetwork(network* net);


### PR DESCRIPTION
To reduce the load of both CPU and GPU, skip detection thread when subscribing no image.