### PR TITLE
remove old compute_35

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -31,7 +31,6 @@ if (CUDA_FOUND)
     CUDA_NVCC_FLAGS
     ${CUDA_NVCC_FLAGS};
     -O3
-    -gencode arch=compute_35,code=sm_35
     -gencode arch=compute_50,code=[sm_50,compute_50]
     -gencode arch=compute_52,code=[sm_52,compute_52]
     -gencode arch=compute_61,code=sm_61


### PR DESCRIPTION
remove compute_35 which is not found in cuda 12.1

https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list